### PR TITLE
Fix Vite base path for GitHub Pages deployment

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/digby-dawgs/',
 })


### PR DESCRIPTION
- Add missing base: '/digby-dawgs/' configuration
- Ensures assets and events.json load correctly on GitHub Pages
- Fixes blank page issue in deployed version

🤖 Generated with [Claude Code](https://claude.ai/code)